### PR TITLE
Update package.yml

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -24,7 +24,19 @@ page:
     subpages:
         wildcard:
             title: 'translate:wildcard'
-        copy:
+        dummy_add: 
+            title: 'sprog-dummy-add'
+            perm: sprog[add_wildcard]
+            hidden: true
+        dummy_delete: 
+            title: 'sprog-dummy-delete'
+            perm: sprog[delete_wildcard]
+            hidden: true
+        dummy_modify: 
+            title: 'sprog-dummy-modfiy'
+            perm: sprog[modify_wildcard]
+            hidden: true
+      copy:
             title: 'translate:copy_content'
             perm: admin[]
             subpages:


### PR DESCRIPTION
Habe hier 3 zuätzliche perms (auf dummypages) angelegt, damit ich diese in der wildcard-pages abfragen kann und dort steuern kann, ob ein Benutzer (bzw. die zugewiesene Rolle) die Erlaubnis hat, auch Wildcards zu ändern.
Hintergrund:  ein Redaktor soll Ersetzung ändern können (also den Ausgabetext), die in einem Modul definiert sind (z.B. Labeltexte in einem Yform) nicht aber den Paltzhalter (der Eingabetext den ich im Modul verwende).